### PR TITLE
Prevent deleting logged in users

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\DB;
 
 class UserController extends Controller
 {
@@ -57,6 +58,12 @@ class UserController extends Controller
 
     public function destroy(User $user)
     {
+        $loggedIn = DB::table('sessions')->where('user_id', $user->id)->exists();
+
+        if ($loggedIn) {
+            return back()->with('modalError', 'Usuário está logado e não pode ser excluído.');
+        }
+
         $user->delete();
         return back();
     }

--- a/resources/views/admin/users.blade.php
+++ b/resources/views/admin/users.blade.php
@@ -35,4 +35,32 @@
 </table>
 {{ $users->links() }}
 </div>
+
+@if (session('modalError'))
+<div id="errorAlertModal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-sm">
+        <div class="modal-content modal-filled bg-danger">
+            <div class="modal-body">
+                <div class="text-center">
+                    <i class="bx bx-error display-6 mt-0 text-white"></i>
+                    <h4 class="mt-3 text-white">Erro</h4>
+                    <p class="mt-3">{{ session('modalError') }}</p>
+                    <button type="button" class="btn btn-light mt-3" data-bs-dismiss="modal">Fechar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endif
+@endsection
+
+@section('scripts')
+@if (session('modalError'))
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var errorModal = new bootstrap.Modal(document.getElementById('errorAlertModal'));
+        errorModal.show();
+    });
+</script>
+@endif
 @endsection


### PR DESCRIPTION
## Summary
- prevent admin from deleting active sessions
- show Base UI modal error when deletion is blocked

## Testing
- `composer install` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa51d3cd0832b80e3dda12430c189