### PR TITLE
Add JWT token generation route

### DIFF
--- a/app/Http/Controllers/Api/AuthTokenController.php
+++ b/app/Http/Controllers/Api/AuthTokenController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Services\JwtService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class AuthTokenController extends Controller
+{
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
+        $user = User::where('email', $data['email'])->first();
+
+        if (!$user || !Hash::check($data['password'], $user->password)) {
+            return response()->json(['message' => 'Invalid credentials.'], 401);
+        }
+
+        $payload = [
+            'user_id' => $user->id,
+            'exp' => now()->addHour()->timestamp,
+        ];
+
+        $token = JwtService::encode($payload, env('JWT_SECRET', 'secret'));
+
+        return response()->json(['token' => $token]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,9 +2,11 @@
 
 use App\Http\Controllers\KommoWebhookController;
 use App\Http\Controllers\Api\ProposalApiController;
+use App\Http\Controllers\Api\AuthTokenController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/kommo/webhook', KommoWebhookController::class);
+Route::post('/token', [AuthTokenController::class, 'store']);
 
 Route::middleware('jwt')->group(function () {
     Route::get('/proposals/{proposal}', [ProposalApiController::class, 'show']);


### PR DESCRIPTION
## Summary
- create `AuthTokenController` to issue JWT tokens
- expose POST `/api/token` endpoint for clients to get a token

## Testing
- `php artisan -V` *(fails: No such file or directory - vendor not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ff67ee724832baa5c78483c178b46