### PR TITLE
Add individual shortcodes for proposal fields

### DIFF
--- a/wordpress/proposta-plugin/README.md
+++ b/wordpress/proposta-plugin/README.md
@@ -1,0 +1,37 @@
+# Proposta API Shortcodes
+
+Este plugin para WordPress busca informações de uma proposta no backend Laravel.
+Ele utiliza o parâmetro `proposta` presente na URL da página para definir o ID a ser consultado na API em `https://maxxidoctor.com.br/api/proposals/{id}`.
+
+## Uso
+
+1. Copie a pasta `proposta-plugin` para o diretório `wp-content/plugins` do seu WordPress.
+2. (Opcional) defina a constante `PROPOSTA_API_TOKEN` no `wp-config.php` caso a API exija autenticação JWT.
+3. Ative o plugin no painel de administração.
+4. Utilize os shortcodes abaixo para exibir cada campo da proposta informada na URL:
+
+```
+[proposta_id]
+[proposta_client_name]
+[proposta_client_email]
+[proposta_client_phone]
+[proposta_amount]
+[proposta_due_date]
+[proposta_kommo_lead_id]
+[proposta_faturamento_medio_mensal]
+[proposta_faturamento_medio_anual]
+[proposta_quantidade_socios_contrato]
+[proposta_tributacao_federal]
+[proposta_media_declaracoes_ano]
+[proposta_media_lancamentos_mes]
+[proposta_quantos_funcionarios]
+[proposta_proposal_url]
+[proposta_tipo_proposta]
+[proposta_economia_por_ano]
+```
+
+Para campos personalizados utilize:
+
+```
+[proposta_custom campo="nome_do_campo"]
+```

--- a/wordpress/proposta-plugin/proposta-plugin.php
+++ b/wordpress/proposta-plugin/proposta-plugin.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Plugin Name: Proposta API Shortcodes
+ * Description: Obtem informacoes de propostas da API do Laravel usando o parametro "proposta" na URL. Fornece shortcodes individuais para cada campo.
+ * Version: 1.1.0
+ */
+
+function proposta_fetch_data() {
+    static $cache = null;
+    if ($cache !== null) {
+        return $cache;
+    }
+
+    $id = isset($_GET['proposta']) ? intval($_GET['proposta']) : 0;
+    if (!$id) {
+        return [];
+    }
+
+    $api_url = 'https://maxxidoctor.com.br/api/proposals/' . $id;
+    $args = [];
+    if (defined('PROPOSTA_API_TOKEN')) {
+        $args['headers'] = ['Authorization' => 'Bearer ' . PROPOSTA_API_TOKEN];
+    }
+
+    $response = wp_remote_get($api_url, $args);
+    if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+        return [];
+    }
+
+    $body = wp_remote_retrieve_body($response);
+    $data = json_decode($body, true);
+    if (!is_array($data)) {
+        return [];
+    }
+
+    $cache = $data;
+    return $data;
+}
+
+function proposta_field_shortcode($field) {
+    $data = proposta_fetch_data();
+    if (!$data) {
+        return '';
+    }
+    $value = $data[$field] ?? '';
+    if (is_array($value)) {
+        $value = json_encode($value);
+    }
+    return esc_html($value);
+}
+
+function proposta_custom_field_shortcode($atts) {
+    $atts = shortcode_atts(['campo' => ''], $atts);
+    $data = proposta_fetch_data();
+    if (!$data || !$atts['campo']) {
+        return '';
+    }
+    $custom = $data['custom_fields'] ?? [];
+    $value = $custom[$atts['campo']] ?? '';
+    if (is_array($value)) {
+        $value = json_encode($value);
+    }
+    return esc_html($value);
+}
+
+function proposta_register_field_shortcodes() {
+    $fields = [
+        'id',
+        'client_name',
+        'client_email',
+        'client_phone',
+        'amount',
+        'due_date',
+        'kommo_lead_id',
+        'faturamento_medio_mensal',
+        'faturamento_medio_anual',
+        'quantidade_socios_contrato',
+        'tributacao_federal',
+        'media_declaracoes_ano',
+        'media_lancamentos_mes',
+        'quantos_funcionarios',
+        'proposal_url',
+        'tipo_proposta',
+        'economia_por_ano',
+    ];
+
+    foreach ($fields as $field) {
+        add_shortcode('proposta_' . $field, function() use ($field) {
+            return proposta_field_shortcode($field);
+        });
+    }
+
+    add_shortcode('proposta_custom', 'proposta_custom_field_shortcode');
+}
+add_action('init', 'proposta_register_field_shortcodes');


### PR DESCRIPTION
## Summary
- enhance WordPress plugin to provide a shortcode for each proposal field
- document the new shortcodes in README

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687ffb8645f0832ba178b4f12ca173bd