### PR TITLE
Improve WordPress plugin security

### DIFF
--- a/wordpress/proposta-plugin/README.md
+++ b/wordpress/proposta-plugin/README.md
@@ -6,7 +6,7 @@ Ele utiliza o parâmetro `proposta` presente na URL da página para definir o ID
 ## Uso
 
 1. Copie a pasta `proposta-plugin` para o diretório `wp-content/plugins` do seu WordPress.
-2. (Opcional) defina a constante `PROPOSTA_API_TOKEN` no `wp-config.php` caso a API exija autenticação JWT.
+2. (Opcional) defina a constante `PROPOSTA_API_TOKEN` no `wp-config.php` caso a API exija autenticação JWT. O token obtido automaticamente pelo plugin é armazenado em um *transient* por uma hora para evitar requisições repetidas.
 3. Ative o plugin no painel de administração.
 4. Utilize os shortcodes abaixo para exibir cada campo da proposta informada na URL:
 


### PR DESCRIPTION
## Summary
- improve token retrieval by caching the token and handling failures
- sanitize JS output to avoid XSS
- add default case in `getPropost`
- document token caching in the plugin README

## Testing
- `php -l wordpress/proposta-plugin/proposta-plugin.php`
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68801e1c5b80832b9a4edd7abd47d8b7