### PR TITLE
Limit Kommo deal update to new proposals

### DIFF
--- a/app/Http/Controllers/KommoWebhookController.php
+++ b/app/Http/Controllers/KommoWebhookController.php
@@ -54,7 +54,9 @@ class KommoWebhookController extends Controller
         $proposal->proposal_url = 'https://maxxidoctor.com.br/proposta-maxxi-doctor/?proposta=' . $proposal->id;
         $proposal->save();
 
-        $this->updateKommoDeal($leadsId, $proposal->proposal_url);
+        if ($proposal->wasRecentlyCreated) {
+            $this->updateKommoDeal($leadsId, $proposal->proposal_url);
+        }
 
         return response()->json(['url' => $proposal->proposal_url]);
     }


### PR DESCRIPTION
## Summary
- only push proposal URL to Kommo when the record is newly created

## Testing
- `php artisan test --testsuite Feature --log-junit phpunit-report.xml` *(fails: missing vendor deps)*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688237a1a37c832bb4b8261d9fc9ee2d